### PR TITLE
Removed usage of package-installed-p

### DIFF
--- a/zetteldeft.el
+++ b/zetteldeft.el
@@ -28,9 +28,8 @@
 
 (require 'deft)
 
-(unless (package-installed-p 'avy)
-  (user-error 'zetteldeft "Avy not installed, required for zd-avy-* functions"))
-(require 'avy)
+(unless (require 'avy nil 'no-error)
+  (user-error "Avy not installed, required for zd-avy-* functions"))
 
 (defgroup zetteldeft nil
   "A zettelkasten on top of deft.")

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -202,9 +202,8 @@ Some declaration.
 #+BEGIN_SRC emacs-lisp
 (require 'deft)
 
-(unless (package-installed-p 'avy)
-  (user-error 'zetteldeft "Avy not installed, required for zd-avy-* functions"))
-(require 'avy)
+(unless (require 'avy nil 'no-error)
+  (user-error "Avy not installed, required for zd-avy-* functions"))
 #+END_SRC
 
 *** Customization


### PR DESCRIPTION
package-installed-p fails when the package system is not initialized.
This happens for example when using the doom-emacs distribution.