### PR TITLE
respect zetteldeft-id-regex when lifting file title

### DIFF
--- a/zetteldeft.el
+++ b/zetteldeft.el
@@ -316,7 +316,7 @@ Prepended by `zetteldeft-title-prefix' and appended by `zetteldeft-title-suffix'
 ZDFILE should be a full path to a note."
   (let ((baseName (file-name-base zdFile)))
     (replace-regexp-in-string
-     "[0-9]\\{2,\\}-[0-9-]+[[:space:]]"
+     (concat zetteldeft-id-regex "+[[:space:]]")
      "" baseName)))
 
 (defun zetteldeft-file-rename ()


### PR DESCRIPTION
When `zetteldeft-id-regex` is set to something other than the default, the file title is not lifted correctly because the regular expression in `zetteldeft--lift-file-title` is hard-coded.