### PR TITLE
`zetteldeft--check` should compare true filenames on both sides.

### DIFF
--- a/zetteldeft.el
+++ b/zetteldeft.el
@@ -366,7 +366,7 @@ whether it has `deft-directory' somewhere in its path."
     (user-error "Buffer not visiting a file"))
   (unless (string-match-p
             (regexp-quote (file-truename deft-directory))
-            (buffer-file-name))
+            (file-truename (buffer-file-name)))
     (user-error "Not in zetteldeft territory")))
 
 (defcustom zetteldeft-title-prefix "#+TITLE: "

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -954,15 +954,15 @@ Signal a user error if it is not.
 The =file-truename= is there to make sure that =deft-directory= is first expanded to an absolute path before comparing it to the file name of the current buffer (which is already an absolute path).
 
 #+BEGIN_SRC emacs-lisp
-(defun zetteldeft--check ()
-  "Check if the currently visited file is in `zetteldeft' territory:
-whether it has `deft-directory' somewhere in its path."
-  (unless (buffer-file-name)
-    (user-error "Buffer not visiting a file"))
-  (unless (string-match-p
-            (regexp-quote (file-truename deft-directory))
-            (buffer-file-name))
-    (user-error "Not in zetteldeft territory")))
+  (defun zetteldeft--check ()
+    "Check if the currently visited file is in `zetteldeft' territory:
+    whether it has `deft-directory' somewhere in its path."
+    (unless (buffer-file-name)
+      (user-error "Buffer not visiting a file"))
+    (unless (string-match-p
+	     (regexp-quote (file-truename deft-directory))
+	     (file-truename (buffer-file-name)))
+      (user-error "Not in zetteldeft territory")))
 #+END_SRC
 
 **** =zetteldeft--insert-title= inserts file title

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -954,15 +954,15 @@ Signal a user error if it is not.
 The =file-truename= is there to make sure that =deft-directory= is first expanded to an absolute path before comparing it to the file name of the current buffer (which is already an absolute path).
 
 #+BEGIN_SRC emacs-lisp
-  (defun zetteldeft--check ()
-    "Check if the currently visited file is in `zetteldeft' territory:
-    whether it has `deft-directory' somewhere in its path."
-    (unless (buffer-file-name)
-      (user-error "Buffer not visiting a file"))
-    (unless (string-match-p
-	     (regexp-quote (file-truename deft-directory))
-	     (file-truename (buffer-file-name)))
-      (user-error "Not in zetteldeft territory")))
+(defun zetteldeft--check ()
+  "Check if the currently visited file is in `zetteldeft' territory:
+whether it has `deft-directory' somewhere in its path."
+  (unless (buffer-file-name)
+    (user-error "Buffer not visiting a file"))
+  (unless (string-match-p
+            (regexp-quote (file-truename deft-directory))
+            (file-truename (buffer-file-name)))
+    (user-error "Not in zetteldeft territory")))
 #+END_SRC
 
 **** =zetteldeft--insert-title= inserts file title


### PR DESCRIPTION
The function `zetteldeft--check` should expand symlinks in the
`deft-directory` as well as the `buffer-file-name`. If the
`true-filename` isn't compared on both, you'll have false mismatches
when the `deft-directory` is in a symlinked folder, like `~/org/`
which is a symlink to `~/Dropbox/org`.

Before the change, this would search for `~/Dropbox/org/` in
`~/org/new-zettel.org`. Now it searches for `~/Dropbox/org/` in
`~/Dropbox/org/new-zettel.org`.