### PR TITLE
Introduce `zetteldeft-list-prefix` for customizing list items

### DIFF
--- a/introduction.org
+++ b/introduction.org
@@ -288,7 +288,7 @@ To make sure that your Markdown notes start with correct title syntax, customize
 (setq zetteldeft-title-prefix "# ")
 #+end_src
 
-To use markdown list syntax, customize =zetteldeft-list-prefix=.
+When using =zetteldeft-insert-list-links=, you might want to change a list entry to correct Markdown syntax, like so:
 
 #+begin_src emacs-lisp
 (setq zetteldeft-list-prefix "* ")

--- a/introduction.org
+++ b/introduction.org
@@ -288,6 +288,12 @@ To make sure that your Markdown notes start with correct title syntax, customize
 (setq zetteldeft-title-prefix "# ")
 #+end_src
 
+To use markdown list syntax, customize =zetteldeft-list-prefix=.
+
+#+begin_src emacs-lisp
+(setq zetteldeft-list-prefix "* ")
+#+end_src
+
 To highlight links you need to set up font-lock keywords for =markdown-mode=.
 
 #+begin_src emacs-lisp

--- a/zetteldeft.el
+++ b/zetteldeft.el
@@ -749,9 +749,15 @@ zetteldeft directory."
       ;; unless the list is empty, then insert a message
       (insert (format zetteldeft-list-links-missing-message zdSrch)))))
 
+(defcustom zetteldeft-list-prefix " - "
+  "Prefix for lists created with `zetteldeft-insert-list-links'
+and `zetteldeft-insert-list-links-missing'."
+  :type 'string
+  :group 'zetteldeft)
+
 (defun zetteldeft--list-entry-file-link (zdFile)
   "Insert ZDFILE as list entry."
-  (insert " - "
+  (insert zetteldeft-list-prefix
           zetteldeft-link-indicator
           (zetteldeft--lift-id (file-name-base zdFile))
           zetteldeft-link-suffix

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -1755,10 +1755,12 @@ Might need to be fixed sometime.
 
 **** =zetteldeft-list-prefix= prefix variable for list items
 
+To define what a list entry looks like, let's create a customizeable string.
+
 #+BEGIN_SRC emacs-lisp
 (defcustom zetteldeft-list-prefix " - "
-  "Prefix for lists created with `zetteldeft-insert-list-links`
-and `zetteldeft-insert-list-links-missing`"
+  "Prefix for lists created with `zetteldeft-insert-list-links'
+and `zetteldeft-insert-list-links-missing'."
   :type 'string
   :group 'zetteldeft)
 #+END_SRC

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -1753,6 +1753,15 @@ zetteldeft directory."
 The final =dolist= contains some ugliness to make things work with =zetteldeft-link-suffix=, in order to get the note's title without the link in it.
 Might need to be fixed sometime.
 
+**** =zetteldeft-list-prefix= prefix variable for list items
+
+#+BEGIN_SRC emacs-lisp
+(defcustom zetteldeft-list-prefix " - "
+  "Prefix for lists created with `zetteldeft-insert-list-links`
+and `zetteldeft-insert-list-links-missing`"
+  :type 'string
+  :group 'zetteldeft)
+#+END_SRC
 **** =zetteldeft--list-entry-file-link= includes a file link as list entry
 
 Inserts for given file a link id and title as a list entry.
@@ -1760,7 +1769,7 @@ Inserts for given file a link id and title as a list entry.
 #+BEGIN_SRC emacs-lisp
 (defun zetteldeft--list-entry-file-link (zdFile)
   "Insert ZDFILE as list entry."
-  (insert " - "
+  (insert zetteldeft-list-prefix
           zetteldeft-link-indicator
           (zetteldeft--lift-id (file-name-base zdFile))
           zetteldeft-link-suffix


### PR DESCRIPTION
For example, if you are using zetteldeft with markdown, you can set this variable to "* ". This allows you to make it so that zetteldeft creates lists like this:

```
* [[id]] foo
* [[id]] bar
```

Rather than the default of " - ", which creates lists like this:

```
 - [[id]] foo
 - [[id]] bar
```

Fixes #85