### PR TITLE
Add `zetteldeft-extract-region-to-note` function

### DIFF
--- a/zetteldeft.el
+++ b/zetteldeft.el
@@ -101,6 +101,9 @@ This can be
 If there is only one result, open that file (unless DNTOPN is true)."
   ;; Sanitize the filter string
   (setq str (replace-regexp-in-string "[[:space:]\n]+" " " str))
+  ;; Switch to Deft window if buffer is currently visible
+  (when (deft-buffer-visible-p)
+    (select-window (deft-buffer-visible-p)))
   ;; Call deft search on the filter string
   (let ((deft-incremental-search t))
    (deft)

--- a/zetteldeft.el
+++ b/zetteldeft.el
@@ -394,6 +394,19 @@ Similar to `zetteldeft-new-file', but insert a link to the new file."
     (newline)
     (zetteldeft--insert-link ogID (zetteldeft--id-to-title ogId))))
 
+(defun zetteldeft-extract-region-to-note (title)
+  "Extract the marked region to a new note with TITLE."
+  (interactive (list (if (not (use-region-p))
+                         (user-error "No region active.")
+                     (read-string "Note title: "))))
+  (let* ((id (zetteldeft-generate-id title))
+         (text (kill-region (region-beginning) (region-end))))
+    (save-excursion
+      (zetteldeft-new-file title id)
+      (yank)
+      (save-buffer))
+    (zetteldeft--insert-link id title)))
+
 ;;;###autoload
 (defun zetteldeft-follow-link ()
   "Follows zetteldeft link to a file if point is on a link.

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -16,6 +16,7 @@ Check out the Github [[https://github.com/EFLS/zetteldeft][repository]] to get t
 Read on for an introduction and some documentation.
 
 Latest additions:
+ - *19 May*: Add =zetteldeft-extract-region-to-note=, thanks to Sodaware
  - *13 May*: Introduce & customize =zetteldeft--insert-link=
  - *11 Mar*: Add =zetteldeft-tag-insert=, thanks to puzan
  - *30 Dec*: Renaming notes will now insert a title if there is none, thanks to jeffvalk
@@ -1049,17 +1050,14 @@ Store a link, generate a new one, and we're done.
     (zetteldeft--insert-link ogID (zetteldeft--id-to-title ogId))))
 #+END_SRC
 
-**** =zetteldeft-extract-region-to-note= creates a new note from a region
+**** =zetteldeft-extract-region-to-note= creates new note from a region
 
-Highlight a region of an existing note and call
-=zetteldeft-extract-region-to-note= to extract the region into a new note.
+Highlight a region of an existing note and call =zetteldeft-extract-region-to-note= to extract the region into a new note.
 
-This function will prompt for a title. Once entered, a new note will be created
-with that title and the highlighted region as its content. The original
-highlighted region will be replaced with a link to this new note.
-
-The inserted link format can be customized through the
-=zetteldeft-insert-note-link-function= variable.
+This function will prompt for a title.
+Once entered, a new note is created with that title and the highlighted region as its content.
+The original highlighted region will be replaced with a link to this new note.
+As with other link insertions, the format of this link can be customized through the =zetteldeft-insert-note-link-function= variable.
 
 #+BEGIN_SRC emacs-lisp
 (defun zetteldeft-extract-region-to-note (title)

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -1057,7 +1057,7 @@ Highlight a region of an existing note and call =zetteldeft-extract-region-to-no
 This function will prompt for a title.
 Once entered, a new note is created with that title and the highlighted region as its content.
 The original highlighted region will be replaced with a link to this new note.
-As with other link insertions, the format of this link can be customized through the =zetteldeft-insert-note-link-function= variable.
+As with other link insertions, the format of this link can be customized through the =zetteldeft-insert-link-function= variable.
 
 #+BEGIN_SRC emacs-lisp
 (defun zetteldeft-extract-region-to-note (title)

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -1361,6 +1361,75 @@ is made."
           (newline))))))
 #+END_SRC
 
+**** =zetteldeft-extract-region-to-note= creates a new note from a region
+
+Highlight a region of an existing note and call
+=zetteldeft-extract-region-to-note= to extract the region into a new note.
+
+This function will prompt for a title. Once entered, a new note will be created
+with that title and the highlighted region as its content. The original
+highlighted region will be replaced with a link to this new note.
+
+The inserted link format can be customized through the
+=zetteldeft-insert-note-link-function= variable.
+
+#+BEGIN_SRC emacs-lisp
+(defun zetteldeft-extract-region-to-note (title)
+  "Extract the marked region to a new note with TITLE."
+  (interactive (list (read-string "Note title: ")))
+  (let* ((deft-use-filename-as-title t)
+         (note-id (zetteldeft-generate-id title))
+         (note-filename (concat note-id zetteldeft-id-filename-separator title))
+         (note-text     (kill-region (region-beginning) (region-end))))
+    (save-excursion
+      (deft-new-file-named note-filename)
+      (zetteldeft--insert-title title)
+      (insert "\n\n")
+      (yank)
+      (save-buffer)
+      (when (featurep 'evil) (evil-insert-state)))
+    (zetteldeft-insert-note-link note-filename title)))
+#+END_SRC
+
+**** =zetteldeft-insert-note-link= inserts a link to a note
+
+Inserts a link to a file with a title.
+
+The inserted link format can be customized through the
+=zetteldeft-insert-note-link-function= variable.
+
+#+BEGIN_SRC emacs-lisp
+(defun zetteldeft-insert-note-link (note title)
+  "Insert a link to NOTE with TITLE as its link text."
+  (interactive)
+  (funcall zetteldeft-insert-note-link-function note title))
+#+END_SRC
+
+**** =zetteldeft-insert-note-link-function= customizes how extracted links are formatted
+
+This is used by =zetteldeft-extract-region-to-note= to format inserted notes. It
+must be a function that takes two parameters:
+
+- ~note~  :: The note identifier.
+- ~title~ :: The title of the note.
+
+The default value is =zetteldeft-insert-note-link-with-prefix=, which inserts
+the prefix character followed by the note ID and its title.
+
+#+BEGIN_SRC emacs-lisp
+(defcustom zetteldeft-insert-note-link-function
+  #'zetteldeft-insert-note-link-with-prefix
+  "The function to use when inserting note links.")
+
+(defun zetteldeft-insert-note-link-with-prefix (note title)
+  "Insert a link to NOTE with TITLE."
+  (insert zetteldeft-link-indicator
+          (zetteldeft--lift-id note)
+          zetteldeft-link-suffix
+          " "
+          title))
+#+END_SRC
+
 **** =zetteldeft-count-words= counts total number of words
 
 To count the total number of words, lets loop over all the files and count words in each.

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -1049,6 +1049,36 @@ Store a link, generate a new one, and we're done.
     (zetteldeft--insert-link ogID (zetteldeft--id-to-title ogId))))
 #+END_SRC
 
+**** =zetteldeft-extract-region-to-note= creates a new note from a region
+
+Highlight a region of an existing note and call
+=zetteldeft-extract-region-to-note= to extract the region into a new note.
+
+This function will prompt for a title. Once entered, a new note will be created
+with that title and the highlighted region as its content. The original
+highlighted region will be replaced with a link to this new note.
+
+The inserted link format can be customized through the
+=zetteldeft-insert-note-link-function= variable.
+
+#+BEGIN_SRC emacs-lisp
+(defun zetteldeft-extract-region-to-note (title)
+  "Extract the marked region to a new note with TITLE."
+  (interactive (list (read-string "Note title: ")))
+  (let* ((deft-use-filename-as-title t)
+         (note-id (zetteldeft-generate-id title))
+         (note-filename (concat note-id zetteldeft-id-filename-separator title))
+         (note-text     (kill-region (region-beginning) (region-end))))
+    (save-excursion
+      (deft-new-file-named note-filename)
+      (zetteldeft--insert-title title)
+      (insert "\n\n")
+      (yank)
+      (save-buffer)
+      (when (featurep 'evil) (evil-insert-state)))
+    (zetteldeft--insert-link (zetteldeft--lift-id note-filename) title)))
+#+END_SRC
+
 *** Moving around with =avy=
 **** Following links with =zetteldeft-follow-link=
 
@@ -1423,36 +1453,6 @@ is made."
         (when zetteldeft-always-insert-title
           (zetteldeft--insert-title title)
           (newline))))))
-#+END_SRC
-
-**** =zetteldeft-extract-region-to-note= creates a new note from a region
-
-Highlight a region of an existing note and call
-=zetteldeft-extract-region-to-note= to extract the region into a new note.
-
-This function will prompt for a title. Once entered, a new note will be created
-with that title and the highlighted region as its content. The original
-highlighted region will be replaced with a link to this new note.
-
-The inserted link format can be customized through the
-=zetteldeft-insert-note-link-function= variable.
-
-#+BEGIN_SRC emacs-lisp
-(defun zetteldeft-extract-region-to-note (title)
-  "Extract the marked region to a new note with TITLE."
-  (interactive (list (read-string "Note title: ")))
-  (let* ((deft-use-filename-as-title t)
-         (note-id (zetteldeft-generate-id title))
-         (note-filename (concat note-id zetteldeft-id-filename-separator title))
-         (note-text     (kill-region (region-beginning) (region-end))))
-    (save-excursion
-      (deft-new-file-named note-filename)
-      (zetteldeft--insert-title title)
-      (insert "\n\n")
-      (yank)
-      (save-buffer)
-      (when (featurep 'evil) (evil-insert-state)))
-    (zetteldeft--insert-link (zetteldeft--lift-id note-filename) title)))
 #+END_SRC
 
 **** =zetteldeft-count-words= counts total number of words

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -390,6 +390,9 @@ Based on snippet suggested by =saf-dmitry= on deft's [[https://github.com/jrblev
 If there is only one result, open that file (unless DNTOPN is true)."
   ;; Sanitize the filter string
   (setq str (replace-regexp-in-string "[[:space:]\n]+" " " str))
+  ;; Switch to Deft window if buffer is currently visible
+  (when (deft-buffer-visible-p)
+    (select-window (deft-buffer-visible-p)))
   ;; Call deft search on the filter string
   (let ((deft-incremental-search t))
    (deft)
@@ -399,6 +402,9 @@ If there is only one result, open that file (unless DNTOPN is true)."
    (when (eq (length deft-current-files) 1)
      (deft-open-file (car deft-current-files)))))
 #+END_SRC
+
+When doing a global search, the Deft buffer is shown.
+To prevent that the Deft buffer is shown in multiple windows, first switch to the relevant window if the Deft buffer is already visible somewhere.
 
 **** =zetteldeft--search-filename= for string
 

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -1062,19 +1062,16 @@ As with other link insertions, the format of this link can be customized through
 #+BEGIN_SRC emacs-lisp
 (defun zetteldeft-extract-region-to-note (title)
   "Extract the marked region to a new note with TITLE."
-  (interactive (list (read-string "Note title: ")))
-  (let* ((deft-use-filename-as-title t)
-         (note-id (zetteldeft-generate-id title))
-         (note-filename (concat note-id zetteldeft-id-filename-separator title))
-         (note-text     (kill-region (region-beginning) (region-end))))
+  (interactive (list (if (not (use-region-p))
+                         (user-error "No region active.")
+                     (read-string "Note title: "))))
+  (let* ((id (zetteldeft-generate-id title))
+         (text (kill-region (region-beginning) (region-end))))
     (save-excursion
-      (deft-new-file-named note-filename)
-      (zetteldeft--insert-title title)
-      (insert "\n\n")
+      (zetteldeft-new-file title id)
       (yank)
-      (save-buffer)
-      (when (featurep 'evil) (evil-insert-state)))
-    (zetteldeft--insert-link (zetteldeft--lift-id note-filename) title)))
+      (save-buffer))
+    (zetteldeft--insert-link id title)))
 #+END_SRC
 
 *** Moving around with =avy=

--- a/zetteldeft.org
+++ b/zetteldeft.org
@@ -1452,46 +1452,7 @@ The inserted link format can be customized through the
       (yank)
       (save-buffer)
       (when (featurep 'evil) (evil-insert-state)))
-    (zetteldeft-insert-note-link note-filename title)))
-#+END_SRC
-
-**** =zetteldeft-insert-note-link= inserts a link to a note
-
-Inserts a link to a file with a title.
-
-The inserted link format can be customized through the
-=zetteldeft-insert-note-link-function= variable.
-
-#+BEGIN_SRC emacs-lisp
-(defun zetteldeft-insert-note-link (note title)
-  "Insert a link to NOTE with TITLE as its link text."
-  (interactive)
-  (funcall zetteldeft-insert-note-link-function note title))
-#+END_SRC
-
-**** =zetteldeft-insert-note-link-function= customizes how extracted links are formatted
-
-This is used by =zetteldeft-extract-region-to-note= to format inserted notes. It
-must be a function that takes two parameters:
-
-- ~note~  :: The note identifier.
-- ~title~ :: The title of the note.
-
-The default value is =zetteldeft-insert-note-link-with-prefix=, which inserts
-the prefix character followed by the note ID and its title.
-
-#+BEGIN_SRC emacs-lisp
-(defcustom zetteldeft-insert-note-link-function
-  #'zetteldeft-insert-note-link-with-prefix
-  "The function to use when inserting note links.")
-
-(defun zetteldeft-insert-note-link-with-prefix (note title)
-  "Insert a link to NOTE with TITLE."
-  (insert zetteldeft-link-indicator
-          (zetteldeft--lift-id note)
-          zetteldeft-link-suffix
-          " "
-          title))
+    (zetteldeft--insert-link (zetteldeft--lift-id note-filename) title)))
 #+END_SRC
 
 **** =zetteldeft-count-words= counts total number of words


### PR DESCRIPTION
This function extracts a highlighted region into a new note, and replaces the old text with a link to the new note. This is an updated version of the code I wrote about in "[Extracting zetteldeft notes](https://www.philnewton.net/blog/extracting-zetteldeft-notes/)" and is more customizable.

By default it inserts a standard zetteldeft link (like `§ 2021-05-06-1127 Example link`), but this can be customized through the `zetteldeft-insert-note-link-function` variable.

